### PR TITLE
Ability to change port number (Fix#5)

### DIFF
--- a/UniversalDashboard.Forge.psm1
+++ b/UniversalDashboard.Forge.psm1
@@ -1,30 +1,30 @@
-function New-UDDesktopApp {  
+function New-UDDesktopApp {
     <#
     .SYNOPSIS
     Generate a desktop app with Universal Dashboard
-    
+
     .DESCRIPTION
-    Generates a desktop application with Universal Dashboard using electron. 
-    
+    Generates a desktop application with Universal Dashboard using electron.
+
     .PARAMETER Path
-    The path to the dashboard.ps1 file you want to create an app out of. 
-    
+    The path to the dashboard.ps1 file you want to create an app out of.
+
     .PARAMETER Name
-    The name of the electron application. 
-    
+    The name of the electron application.
+
     .PARAMETER OutputPath
-    The output path for the application. 
-    
+    The output path for the application.
+
     .EXAMPLE
     New-UDDesktopApp -Path "./dashboard.ps1" -OutputPath "./out" -Name "MyApp"
-    
+
     .NOTES
-    This cmdlet requires NodeJS to be installed. 
+    This cmdlet requires NodeJS to be installed.
     #>
-      
+
     param(
         [Parameter(Mandatory)]
-        $Path, 
+        $Path,
         [Parameter(Mandatory)]
         $Name,
         [Parameter()]
@@ -35,12 +35,12 @@ function New-UDDesktopApp {
     )
 
     End {
-        $Npx = Get-Command npx 
+        $Npx = Get-Command npx
         if ($null -eq $Npx)
         {
             throw "NodeJS is required to run New-UDDesktopApp. Download here: https://nodejs.org"
         }
-    
+
         if ($null -eq $OutputPath)
         {
             $OutputPath = $PSScriptRoot
@@ -54,36 +54,38 @@ function New-UDDesktopApp {
             $OutputPath = $pathHelper.GetUnresolvedProviderPathFromPSPath($OutputPath, [ref]$provider, [ref]$drive)
             Write-Verbose "Output path resolved to: $OutputPath"
         }
-    
+
         if (Test-Path (Join-Path $OutputPath $Name))
         {
             Write-Verbose "Output path exists. Removing existing output path."
             Remove-Item (Join-Path $OutputPath $Name) -Force -Recurse
         }
-    
+
         if (-not (Test-Path $OutputPath))
         {
             Write-Verbose "Output path does not exist. Creating new output path."
             New-Item -Path $OutputPath -ItemType Directory | Out-Null
         }
-    
+
         Push-Location $OutputPath
         Write-Verbose "Creating electron app $Name"
+        npm install create-electron-app@latest --global
         npx create-electron-app $Name
         Pop-Location
-    
+
         $src = [IO.Path]::Combine($OutputPath, $Name, 'src')
 
         Write-Verbose "Copying dashboard and index.js to electron src folder: $src"
-    
+
         Copy-Item -Path $Path -Destination $src
         Copy-Item -Path (Join-Path $PSScriptRoot "index.js" ) -Destination $src -Force
         $IndexJs = Join-Path $src "index.js"
 
-        Set-ForgeVariable -IndexPath $IndexJs -PowerShellHost $PowerShellHost
+        $port = Get-PortNumber -Path $Path
+        Set-ForgeVariable -IndexPath $IndexJs -PowerShellHost $PowerShellHost -Port $port
 
         Write-Verbose "Building electron app with forge"
-    
+
         npm i -g @electron-forge/cli
         Set-Location (Join-Path $OutputPath $Name)
         electron-forge make
@@ -93,12 +95,27 @@ function New-UDDesktopApp {
 function Set-ForgeVariable {
     param(
         $IndexPath,
-        $PowerShellHost
+        $PowerShellHost,
+        $Port
     )
 
     $Content = Get-Content -Path $IndexPath -Raw
 
     Write-Verbose "Setting ForgeVariable PowerShellHost: $PowerShellHost"
     $Content = $Content.Replace('$PowerShellHost', $PowerShellHost)
+
+    Write-Verbose "Setting ForgeVariable Port: $Port"
+    $Content = $Content.Replace('$Port', $Port)
+
     $Content | Out-File -FilePath $IndexPath -Force -Encoding utf8
+}
+
+function Get-PortNumber {
+    param (
+        $Path
+    )
+
+    $content = Get-Content -Path $Path
+
+    if (-not ([regex]::Match($content, '[sS]tart-[uUdD]{3}ash.+-Port (\d+)').Success)) { 80 }
 }

--- a/UniversalDashboard.Forge.psm1
+++ b/UniversalDashboard.Forge.psm1
@@ -116,6 +116,7 @@ function Get-PortNumber {
     )
 
     $content = Get-Content -Path $Path
+    $match = [regex]::Match($content, '[sS]tart-[uUdD]{3}ash.+-Port (\d+)')
 
-    if (-not ([regex]::Match($content, '[sS]tart-[uUdD]{3}ash.+-Port (\d+)').Success)) { 80 }
+    if ($match.Success) { $match.Groups[1].Value } else { 80 }
 }

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ const createWindow = () => {
   setTimeout(function() {
 
     // and load the index.html of the app.
-    mainWindow.loadURL('http://127.0.0.1:8001')
-  
+    mainWindow.loadURL('http://127.0.0.1:$Port')
+
   }, 1000)
 
   // Emitted when the window is closed.


### PR DESCRIPTION
Accidentally closed my previous pull request (#13)

I don't feel 100% with this approach. I'm not sure the regex and new function are the right way to handle this.

The other option would be to add a ```$Port``` parameter to ```New-UDDesktopApp``` and just document that the user needs to make sure the port in the ```dashboard.ps1``` is the same as the port when creating the app.